### PR TITLE
fixing flickering

### DIFF
--- a/src/alc_rx.h
+++ b/src/alc_rx.h
@@ -39,9 +39,9 @@
 //#define __ALC_RX_ENABLE_DEBUG 1
 //#define __ALC_RX_ENABLE_TRACE 1
 //
-//#define println(...) printf(__VA_ARGS__);printf("\r\n")
+//#define println(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 //
-//#define __ALC_RX_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+//#define __ALC_RX_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 //#define __ALC_RX_PRINTF(...)  printf(__VA_ARGS__);
 //
 //#define ALC_RX_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);__ALC_RX_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_alc_rx.h
+++ b/src/atsc3_alc_rx.h
@@ -43,9 +43,9 @@
 // #define __ALC_RX_ENABLE_DEBUG 1
 // #define __ALC_RX_ENABLE_TRACE 1
 
-#define println(...) printf(__VA_ARGS__);printf("\r\n")
+#define println(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 
-#define __ALC_RX_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define __ALC_RX_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __ALC_RX_PRINTF(...)  printf(__VA_ARGS__);
 
 #define ALC_RX_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);__ALC_RX_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_lls.h
+++ b/src/atsc3_lls.h
@@ -50,7 +50,7 @@ int build_aeat_table(lls_table_t* lls_table, xml_node_t* xml_root);
 int build_onscreen_message_notification_table(lls_table_t* lls_table, xml_node_t* xml_root);
 
 
-#define _LLS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _LLS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _LLS_PRINTF(...)  printf(__VA_ARGS__);
 
 #define _LLS_ERROR(...)   printf("%s:%d:ERROR:%.4f: ",__FILE__,__LINE__, gt());_LLS_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_lls_alc_utils.h
+++ b/src/atsc3_lls_alc_utils.h
@@ -23,7 +23,7 @@
 #include "atsc3_lls_sls_parser.h"
 
 
-#define _LLS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _LLS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _LLS_PRINTF(...)  printf(__VA_ARGS__);
 
 #define __LLSU_TRACE(...)

--- a/src/atsc3_lls_mmt_utils.h
+++ b/src/atsc3_lls_mmt_utils.h
@@ -42,7 +42,7 @@ lls_sls_mmt_monitor_t* lls_monitor_sls_mmt_session_create(lls_service_t* lls_ser
 void lls_sls_mmt_session_free(lls_sls_mmt_session_t** lls_session_ptr);
 
 
-#define _LLS_MMT_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _LLS_MMT_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _LLS_MMT_PRINTF(...)  printf(__VA_ARGS__);
 
 #define __LLSU_MMT_TRACE(...)

--- a/src/atsc3_lls_sls_monitor_output_buffer_utils.h
+++ b/src/atsc3_lls_sls_monitor_output_buffer_utils.h
@@ -62,7 +62,7 @@ pthread_mutex_t* lls_sls_monitor_reader_mutext_create();
 void lls_sls_monitor_reader_mutex_lock(pthread_mutex_t* pthread_mutex);
 void lls_sls_monitor_reader_mutex_unlock(pthread_mutex_t* pthread_mutex);
 
-#define __LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define __LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_ERROR(...)   printf("%s:%d:ERROR :",__FILE__,__LINE__);__LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_PRINTLN(__VA_ARGS__);
 #define __LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_WARN(...)    printf("%s:%d:WARN :",__FILE__,__LINE__);__LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_PRINTLN(__VA_ARGS__);
 #define __LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_INFO(...)    printf("%s:%d:INFO :",__FILE__,__LINE__);__LLS_SLS_MONITOR_OUTPUT_BUFFER_UTILS_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_lls_sls_parser.h
+++ b/src/atsc3_lls_sls_parser.h
@@ -61,7 +61,7 @@ extern int _LLS_SLT_UTILS_DEBUG_ENABLED;
 
 
 
-#define _LLS_SLT_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _LLS_SLT_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _LLS_SLT_UTILS_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_LLS_SLT_UTILS_PRINTLN(__VA_ARGS__);
 #define _LLS_SLT_UTILS_WARN(...)    printf("%s:%d:WARN:",__FILE__,__LINE__);_LLS_SLT_UTILS_PRINTLN(__VA_ARGS__);
 #define _LLS_SLT_UTILS_INFO(...)    printf("%s:%d:INFO:",__FILE__,__LINE__);_LLS_SLT_UTILS_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_lls_slt_parser.h
+++ b/src/atsc3_lls_slt_parser.h
@@ -60,7 +60,7 @@ int SLT_BROADCAST_SVC_SIGNALING_build_table(lls_service_t* service_table, xml_no
 }
 #endif
 
-#define __LLS_SLT_PARSER_PRINTLN(...) 	 printf(__VA_ARGS__);printf("\r\n")
+#define __LLS_SLT_PARSER_PRINTLN(...) 	 printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __LLS_SLT_PARSER_ERROR(...)  	 printf("%s:%d:ERROR:",__FILE__,__LINE__);__LLS_SLT_PARSER_PRINTLN(__VA_ARGS__);
 #define __LLS_SLT_PARSER_WARN(...)   	 printf("%s:%d:WARN:",__FILE__,__LINE__);__LLS_SLT_PARSER_PRINTLN(__VA_ARGS__);
 #define __LLS_SLT_PARSER_INFO(...)   	 if(_LLS_SLT_PARSER_INFO_ENABLED) 		{ printf("%s:%d:INFO:",__FILE__,__LINE__);__LLS_SLT_PARSER_PRINTLN(__VA_ARGS__); }

--- a/src/atsc3_mime_multipart_related_parser.h
+++ b/src/atsc3_mime_multipart_related_parser.h
@@ -29,7 +29,7 @@ atsc3_mime_multipart_related_instance_t* atsc3_mime_multipart_related_parser(FIL
 void atsc3_mime_multipart_related_instance_dump(atsc3_mime_multipart_related_instance_t* atsc3_mime_multipart_related_instance);
 
 
-#define __MIME_PARSER_PRINTLN(...)  printf(__VA_ARGS__);printf("\r\n")
+#define __MIME_PARSER_PRINTLN(...)  printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __MIME_PARSER_ERROR(...)  	printf("%s:%d:ERROR:",__FILE__,__LINE__);__MIME_PARSER_PRINTLN(__VA_ARGS__);
 #define __MIME_PARSER_WARN(...)   	printf("%s:%d:WARN:",__FILE__,__LINE__);__MIME_PARSER_PRINTLN(__VA_ARGS__);
 #define __MIME_PARSER_INFO(...)   	if(_MIME_PARSER_INFO_ENABLED)  { printf("%s:%d:INFO:",__FILE__,__LINE__);__MIME_PARSER_PRINTLN(__VA_ARGS__); }

--- a/src/atsc3_mmt_mpu_parser.h
+++ b/src/atsc3_mmt_mpu_parser.h
@@ -9,7 +9,7 @@
 #define ATSC3_MMT_MPU_PARSER_H_
 
 
-#define _MPU_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _MPU_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _MPU_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_MPU_PRINTLN(__VA_ARGS__);
 #define _MPU_WARN(...)    printf("%s:%d:WARN:",__FILE__,__LINE__);_MPU_PRINTLN(__VA_ARGS__);
 #define _MPU_INFO(...)    printf("%s:%d:INFO:",__FILE__,__LINE__);_MPU_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_mmtp_types.h
+++ b/src/atsc3_mmtp_types.h
@@ -280,7 +280,7 @@ typedef struct mmtp_sub_flow {
 typedef struct ATSC3_VECTOR(mmtp_sub_flow_t*) mmtp_sub_flow_vector_t;
 
 
-#define _MMTP_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _MMTP_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _MMTP_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_MMTP_PRINTLN(__VA_ARGS__);
 #define _MMTP_WARN(...)    printf("%s:%d:WARN:",__FILE__,__LINE__);_MMTP_PRINTLN(__VA_ARGS__);
 #define _MMTP_INFO(...)    //printf("%s:%d:INFO ",__FILE__,__LINE__);_MMTP_PRINTLN(__VA_ARGS__);

--- a/src/atsc3_utils.h
+++ b/src/atsc3_utils.h
@@ -144,11 +144,11 @@ uint16_t parsePortIntoIntval(char* dst_port);
 #endif
 
 
-#define println(...) printf(__VA_ARGS__);printf("\r\n")
-#define __PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define println(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
+#define __PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __PRINTF(...)  printf(__VA_ARGS__);
 
-#define _ATSC3_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _ATSC3_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _ATSC3_UTILS_PRINTF(...)  printf(__VA_ARGS__);
 
 #define _ATSC3_UTILS_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_ATSC3_UTILS_PRINTLN(__VA_ARGS__);

--- a/src/listener_tests/atsc3_listener_test.cpp
+++ b/src/listener_tests/atsc3_listener_test.cpp
@@ -48,9 +48,9 @@ extern int _MPU_DEBUG_ENABLED;
 extern int _MMTP_DEBUG_ENABLED;
 extern int _LLS_DEBUG_ENABLED;
 
-#define println(...) printf(__VA_ARGS__);printf("\r\n")
+#define println(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 
-#define __PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define __PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define __PRINTF(...)  printf(__VA_ARGS__);
 
 #define __ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);__PRINTLN(__VA_ARGS__);

--- a/src/todo-port.c
+++ b/src/todo-port.c
@@ -308,7 +308,7 @@
 //
 //
 //
-//#define _MMT_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+//#define _MMT_UTILS_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 //#define _MMT_UTILS_PRINTF(...)  printf(__VA_ARGS__);
 //
 //#define _MMT_UTILS_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_MMT_UTILS_PRINTLN(__VA_ARGS__);

--- a/src/xml.h
+++ b/src/xml.h
@@ -168,7 +168,7 @@ uint8_t* xml_attributes_clone_node(xml_node_t* node);
 
 
 
-#define _XML_PRINTLN(...) printf(__VA_ARGS__);printf("\r\n")
+#define _XML_PRINTLN(...) printf(__VA_ARGS__);printf("%s%s","\r","\n")
 #define _XML_PRINTF(...)  printf(__VA_ARGS__);
 
 #define _XML_ERROR(...)   printf("%s:%d:ERROR:",__FILE__,__LINE__);_XML_PRINTLN(__VA_ARGS__);


### PR DESCRIPTION
fixing gcc optimized out printf("\r\n") as this was causing flickering with printf overload in final linkage stage to debug.log