### PR TITLE
atsc3_fdt: fixing possible doublefree in atsc3_fdt_instance_free due …

### DIFF
--- a/src/atsc3_fdt.c
+++ b/src/atsc3_fdt.c
@@ -63,7 +63,7 @@ void atsc3_fdt_instance_free(atsc3_fdt_instance_t** atsc3_fdt_instance_p) {
             free(atsc3_fdt_instance);
             atsc3_fdt_instance = NULL;
         }
-        atsc3_fdt_instance_p = NULL;
+        *atsc3_fdt_instance_p = NULL;
     }
 }
 

--- a/src/phy/virtual/PcapSTLTPVirtualPHY.cpp
+++ b/src/phy/virtual/PcapSTLTPVirtualPHY.cpp
@@ -38,6 +38,10 @@ PcapSTLTPVirtualPHY::PcapSTLTPVirtualPHY() {
 	atsc3_stltp_depacketizer_context->atsc3_stltp_baseband_alp_packet_collection_callback_context = (void*)this;
 }
 
+/*
+ * jjustman-2020-10-02 - NOTE: if the STLTP dst_ip and dst_port aren't known, don't call this method and we will auto-determine
+ * 						 these values from a matching RTP header frame
+ */
 
 void PcapSTLTPVirtualPHY::atsc3_pcap_stltp_listen_ip_port_plp(string ip, string port, uint8_t plp) {
 

--- a/src/tools/atsc3_alc_listener_mde_writer_from_stltp_pcap.cpp
+++ b/src/tools/atsc3_alc_listener_mde_writer_from_stltp_pcap.cpp
@@ -253,6 +253,8 @@ int main(int argc,char **argv) {
 
 	char *filename;
 
+	bool stltp_dst_ip_and_port_manually_configured = false;
+
     char *stltp_dst_ip = "239.239.239.239";
     char *stltp_dst_port = "30000";
 
@@ -287,8 +289,8 @@ int main(int argc,char **argv) {
         __INFO("opening STLTP pcap for replay: %s", filename);
 
     } else if(argc==4) {
-
-    	//listen to a selected flow
+    	//listen to a user-specificed STLTP flow
+    	stltp_dst_ip_and_port_manually_configured = true;
 
     	filename = argv[1];
 		stltp_dst_ip = argv[2];
@@ -296,7 +298,10 @@ int main(int argc,char **argv) {
 		
 		__INFO("opening STLTP pcap for replay: %s, stltp dst_ip: %s, stltp dst_port: %s", filename, stltp_dst_ip, stltp_dst_port);
     } else if (argc==6) {
-		stltp_dst_ip = argv[2];
+    	//listen to a user-specificed STLTP and ALC flow
+      	stltp_dst_ip_and_port_manually_configured = true;
+
+      	stltp_dst_ip = argv[2];
 		stltp_dst_port = argv[3];
 
 		dst_ip = argv[4];
@@ -366,7 +371,10 @@ int main(int argc,char **argv) {
 	//atsc3_core_service_bridge_process_packet_phy(phy_payload_to_process);
 
 	pcapSTLTPVirtualPHY->setRxUdpPacketProcessCallback(phy_rx_udp_packet_process_callback);
-	pcapSTLTPVirtualPHY->atsc3_pcap_stltp_listen_ip_port_plp(stltp_dst_ip, stltp_dst_port, ATSC3_STLTP_DEPACKETIZER_ALL_PLPS_VALUE);
+	if(stltp_dst_ip_and_port_manually_configured) {
+		//auto-detect STLTP dst_ip and dst_port from RTP header frame presence
+		pcapSTLTPVirtualPHY->atsc3_pcap_stltp_listen_ip_port_plp(stltp_dst_ip, stltp_dst_port, ATSC3_STLTP_DEPACKETIZER_ALL_PLPS_VALUE);
+	}
 	pcapSTLTPVirtualPHY->atsc3_pcap_replay_open_file(filename);
 
 	pcapSTLTPVirtualPHY->atsc3_pcap_thread_run();


### PR DESCRIPTION
…to not properly setting *atsc3_fdt_instance_p to NULL, adding STLTP auto-detect of dst_ip and dst_port in atsc3_alc_listener_mde_writer_from_stltp_pcap