### PR TITLE
Fix segfault and other illegal memory management

### DIFF
--- a/WpdPack/Examples-pcap/UDPdump/udpdump.c
+++ b/WpdPack/Examples-pcap/UDPdump/udpdump.c
@@ -139,7 +139,7 @@ int main()
 							 errbuf			// error buffer
 							 )) == NULL)
 	{
-		fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n");
+		fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n", d->name);
 		/* Free the device list */
 		pcap_freealldevs(alldevs);
 		return -1;

--- a/WpdPack/Examples-remote/UDPdump/udpdump.c
+++ b/WpdPack/Examples-remote/UDPdump/udpdump.c
@@ -127,7 +127,7 @@ struct bpf_program fcode;
 							 errbuf		// error buffer
 							 ) ) == NULL)
 	{
-		fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n");
+		fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n", d->name);
 		/* Free the device list */
 		pcap_freealldevs(alldevs);
 		return -1;

--- a/src/atsc3_gzip.c
+++ b/src/atsc3_gzip.c
@@ -257,7 +257,10 @@ int32_t atsc3_unzip_gzip_payload_block_t_with_dynamic_realloc(block_t* src, bloc
 	ret = inflateInit2(&strm, 16+MAX_WBITS);
 
 	if (ret != Z_OK)
+	{
+	   freeclean((void**)&output_payload);
 	   return ret;
+	}
 
 	do {
 		strm.next_in = &input_payload[input_payload_offset];

--- a/src/atsc3_gzip.c
+++ b/src/atsc3_gzip.c
@@ -64,7 +64,7 @@ int32_t atsc3_unzip_gzip_payload(uint8_t* input_payload, uint32_t input_payload_
 			break;
 
 		do {
-			strm.avail_out = output_payload_available;
+			strm.avail_out = output_payload_available - output_payload_offset;
 			strm.next_out = &output_payload[output_payload_offset];
 
 			ret = inflate(&strm, Z_NO_FLUSH);
@@ -179,7 +179,7 @@ int32_t atsc3_unzip_gzip_payload_block_t(block_t* src, block_t* dest) {
 			break;
 
 		do {
-			strm.avail_out = output_payload_available;
+			strm.avail_out = output_payload_available - output_payload_offset;
 			strm.next_out = &output_payload[output_payload_offset];
 
 			ret = inflate(&strm, Z_NO_FLUSH);

--- a/src/atsc3_lls.c
+++ b/src/atsc3_lls.c
@@ -84,6 +84,7 @@ static atsc3_lls_table_t* __lls_create_base_table_raw(block_t* lls_packet_block)
 
 	if(!remaining_payload_size || remaining_payload_size == 65536) {
 	    _LLS_ERROR("__lls_create_base_table_raw: remaining payload size is: %d, invalid, returning NULL!", remaining_payload_size);
+	    free(base_table);
 	    return NULL;
 	}
 

--- a/src/atsc3_mmt_mpu_utils.c
+++ b/src/atsc3_mmt_mpu_utils.c
@@ -437,6 +437,10 @@ void mmtp_mpu_dump_flow(uint32_t dst_ip, uint16_t dst_port, mmtp_mpu_packet_t* m
 	} else if(mmtp_mpu_packet->du_mfu_block) {
 		__MMT_MPU_DEBUG("mmtp_mpu_dump_flow: du_mfu_block            (0x2), file dump to: %s, size: %d", myFilePathName, block_Remaining_size(mmtp_mpu_packet->du_mfu_block));
 		du_block_to_write = mmtp_mpu_packet->du_mfu_block;
+	} else {
+        __MMT_MPU_DEBUG("mmtp_mpu_dump_flow: no block written to file: %s", myFilePathName);
+        fclose(f);
+        return;
 	}
 
 	block_Rewind(du_block_to_write);

--- a/src/atsc3_route_sls_processor.c
+++ b/src/atsc3_route_sls_processor.c
@@ -417,7 +417,7 @@ int32_t atsc3_sls_write_mime_multipart_related_payload_to_file(atsc3_mime_multip
 		}
 		freeclean((void**)&mbms_filename);
 	} else {
-		_ATSC3_ROUTE_SLS_PROCESSOR_WARN("atsc3_sls_write_mime_multipart_related_payload_to_file: sls mbms fragment dump, 0 byte payload? original content_location: %s,local path: %s, atsc3_mime_multipart_related_payload->payload: %p",atsc3_mime_multipart_related_payload->sanitizied_content_location, mbms_filename, atsc3_mime_multipart_related_payload->payload );
+		_ATSC3_ROUTE_SLS_PROCESSOR_WARN("atsc3_sls_write_mime_multipart_related_payload_to_file: sls mbms fragment dump, 0 byte payload? original content_location: %s, atsc3_mime_multipart_related_payload->payload: %p",atsc3_mime_multipart_related_payload->sanitizied_content_location, atsc3_mime_multipart_related_payload->payload );
 	}
 	
 	return bytes_written;

--- a/src/atsc3_sl_tlv_demod_type.c
+++ b/src/atsc3_sl_tlv_demod_type.c
@@ -182,6 +182,7 @@ restart_parsing:
 
         block_Seek_Relative(atsc3_sl_tlv_payload_unparsed_block, to_discard_from_unparsed_block_length);
 
+		free(atsc3_sl_tlv_payload);
 		return NULL;
 	} else {
 		//don't add this value yet if our TLV payload size is incomplete in our block_t, add it in "TLV packet is in this block_t boundary"

--- a/src/listener_tests/atsc3_alc_listener_test.cpp
+++ b/src/listener_tests/atsc3_alc_listener_test.cpp
@@ -186,7 +186,7 @@ int main(int argc,char **argv) {
 		dst_ip_addr_filter = &dst_ip_int;
 
 		__INFO("listening on dev: %s, dst_ip: %s, dst_port: %s", dev, dst_ip, dst_port);
-		uint16_t dst_port_int = parsePortIntoIntval(dst_port);
+		static uint16_t dst_port_int = parsePortIntoIntval(dst_port);
 		dst_ip_port_filter = &dst_port_int;
 
     } else {

--- a/src/test/atsc3_mmt_mpu_packet_test.c
+++ b/src/test/atsc3_mmt_mpu_packet_test.c
@@ -31,12 +31,12 @@ block_t* get_ip_frame_payload_from_raw_ether_filename(const char* file_name) {
 
 	block_t* payload = block_Alloc(st.st_size - PHY_FRAME_PAYLOAD_START);
 
-	FILE* fp = fopen(file_name, "r");
 	if(st.st_size < 14) {
 		__MMSM_ERROR("alc_get_payload_from_filename: size too small - must be greater than 14 - size: %lld file: %s", st.st_size, file_name);
 		return NULL;
 	}
 
+	FILE* fp = fopen(file_name, "r");
 	fseek(fp, PHY_FRAME_PAYLOAD_START, SEEK_SET);
 	fread(payload->p_buffer, st.st_size - PHY_FRAME_PAYLOAD_START, 1, fp);
     payload->i_pos = 0;

--- a/src/test/atsc3_mmt_signalling_packet_test.c
+++ b/src/test/atsc3_mmt_signalling_packet_test.c
@@ -32,12 +32,12 @@ block_t* get_ip_frame_payload_from_raw_ether_filename(const char* file_name) {
 
 	block_t* payload = block_Alloc(st.st_size - PHY_FRAME_PAYLOAD_START);
 
-	FILE* fp = fopen(file_name, "r");
 	if(st.st_size < 14) {
 		__MMSM_ERROR("alc_get_payload_from_filename: size too small - must be greater than 14 - size: %lld file: %s", st.st_size, file_name);
 		return NULL;
 	}
 
+	FILE* fp = fopen(file_name, "r");
 	fseek(fp, PHY_FRAME_PAYLOAD_START, SEEK_SET);
 	fread(payload->p_buffer, st.st_size - PHY_FRAME_PAYLOAD_START, 1, fp);
     payload->i_pos = 0;

--- a/src/test/atsc3_rfcatcher_iq_signed_12_bit_to_hackrf_8_bit_downsampler_test.c
+++ b/src/test/atsc3_rfcatcher_iq_signed_12_bit_to_hackrf_8_bit_downsampler_test.c
@@ -52,7 +52,8 @@ int main(int argc, char* argv[] ) {
     fp_out = fopen(RFCATCHER_TO_HACKRF_DOWNSAMPLER_OUTPUT_FILENAME, "w");
     
     if(!fp_out) {
-        _ATSC3_RFCATCHER_TO_HACKRF_DOWNSAMPLER_TEST_ERROR("atsc3_rfcatcher_iq_signed_12_bit_to_hackrf_8_bit_downsampler_test: %s, ERROR: unable to open output file, %s", RFCATCHER_TO_HACKRF_DOWNSAMPLER_OUTPUT_FILENAME);
+        _ATSC3_RFCATCHER_TO_HACKRF_DOWNSAMPLER_TEST_ERROR("atsc3_rfcatcher_iq_signed_12_bit_to_hackrf_8_bit_downsampler_test: ERROR: unable to open output file, %s", RFCATCHER_TO_HACKRF_DOWNSAMPLER_OUTPUT_FILENAME);
+        fclose(fp_in);
         return -3;
     }
 
@@ -81,7 +82,7 @@ int main(int argc, char* argv[] ) {
         fpos_out += 1;
         
         if((fpos_in % LOG_STATUS_PROGRESS_EVERY_N_BYTES == 0)) {
-            _ATSC3_RFCATCHER_TO_HACKRF_DOWNSAMPLER_TEST_TRACE("Read in sample value 0x%04x (%d), converted to 0x%02x (%d), fpos_in: %d, fpos_out: %d, remaining:  %zu",
+            _ATSC3_RFCATCHER_TO_HACKRF_DOWNSAMPLER_TEST_TRACE("Read in sample value 0x%04x (%d), converted to 0x%02x (%d), fpos_in: %ld, fpos_out: %ld, remaining:  %zu",
                                                           sample_in_12bit,
                                                           sample_in_12bit,
                                                           sample_out_8bit,


### PR DESCRIPTION
This patch fixes the following segfault:
Program terminated with signal 11, Segmentation fault.
#0  atsc3_stltp_raw_packet_extract_inner_from_outer_packet (atsc3_stltp_depacketizer_context=0x14ca010, ip_udp_rtp_ctp_packet=0x17e9e60, 
    atsc3_stltp_tunnel_packet_last=0x0) at atsc3_stltp_parser.c:497
497				if(atsc3_stltp_tunnel_packet_current->ip_udp_rtp_ctp_packet_inner->data) {

Also it fixes minor errors found by cppcheck and sanitizer (illegal memory management & memleaks).