### PR TITLE
Fix segfault with absent unsafe_content_location

### DIFF
--- a/src/atsc3_route_package_utils.c
+++ b/src/atsc3_route_package_utils.c
@@ -164,9 +164,12 @@ atsc3_route_package_extracted_envelope_metadata_and_payload_t* atsc3_route_packa
 						atsc3_mbms_metadata_item_t* atsc3_mbms_metadata_item = atsc3_route_package_extracted_envelope_metadata_and_payload->atsc3_mbms_metadata_envelope->atsc3_mbms_metadata_item_v.data[i-1];
 
 						__ROUTE_PACKAGE_UTILS_DEBUG("comparing atsc3_mbms_metadata_item->metadata_uri: %s, atsc3_mime_multipart_related_payload->unsafe_content_location: %s",
-								atsc3_mbms_metadata_item->metadata_uri, atsc3_mime_multipart_related_payload->unsafe_content_location);
+								atsc3_mbms_metadata_item->metadata_uri,
+								atsc3_mime_multipart_related_payload->unsafe_content_location ? atsc3_mime_multipart_related_payload->unsafe_content_location : "");
 
-						if(!strcasecmp(atsc3_mbms_metadata_item->metadata_uri, atsc3_mime_multipart_related_payload->unsafe_content_location)) {
+						if(atsc3_mime_multipart_related_payload->unsafe_content_location &&
+						   !strcasecmp(atsc3_mbms_metadata_item->metadata_uri, atsc3_mime_multipart_related_payload->unsafe_content_location)) {
+
 							atsc3_mime_multipart_related_payload->version = atsc3_mbms_metadata_item->version;
 							if(atsc3_mbms_metadata_item->content_type) {
 									atsc3_mime_multipart_related_payload->content_type = strdup(atsc3_mbms_metadata_item->content_type);

--- a/src/atsc3_route_sls_processor.c
+++ b/src/atsc3_route_sls_processor.c
@@ -679,6 +679,9 @@ atsc3_route_dash_metadata_t* atsc3_route_sls_extract_cenc_pssh_metadata_if_avail
 
 	block_Rewind(atsc3_mime_multipart_related_payload->payload);
 	xml_document_t* xml_document = xml_parse_document(block_Get(atsc3_mime_multipart_related_payload->payload), block_Remaining_size(atsc3_mime_multipart_related_payload->payload));
+	if(!xml_document) {
+	    return NULL;
+	}
 
 	//look for our first adaptation set
 

--- a/src/atsc3_stltp_depacketizer.c
+++ b/src/atsc3_stltp_depacketizer.c
@@ -368,8 +368,8 @@ void atsc3_stltp_depacketizer_from_ip_udp_rtp_ctp_packet(atsc3_ip_udp_rtp_ctp_pa
 
 							_ATSC3_STLTP_DEPACKETIZER_ERROR("  atsc3_baseband_packet->alp_payload_post_pointer, discarding atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending, was: %p, type 0x%02x, i_pos: %d, p_size: %d", atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending,
 									atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_packet_header.packet_type,
-									atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload->i_pos,
-									atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload->p_size);
+									atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload ? atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload->i_pos : 0,
+									atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload ? atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending->alp_payload->p_size : 0);
 							atsc3_alp_packet_free(&atsc3_stltp_tunnel_packet_processed->atsc3_stltp_tunnel_baseband_packet_pending_by_plp->atsc3_alp_packet_pending);
 						}
 						


### PR DESCRIPTION
This patch fixes the following segfault:
Program terminated with signal 11, Segmentation fault.
#1  0x00000000004818bc in atsc3_route_package_extract_unsigned_payload (filename=0x7f4b27e15630 "route/5003/App.pkg", 
    package_extract_path=0x7f4b1a5fc830 "01be9eeaaf0aa8392a6a5f72ba610bb161ff5a63a75b71e28167252836bcab20") at atsc3_route_package_utils.c:169
#2  0x0000000000448968 in atsc3_alc_packet_persist_to_toi_resource_process_sls_mbms_and_emit_callback (udp_flow=0x7f4b1069ce90, alc_packet=0x7f4b106d6cc0, 
    lls_sls_alc_monitor=0x7f4b18004890, atsc3_route_object=0x7f4b18002680) at atsc3_alc_utils.c:1016
#3  0x0000000000403f9b in process_packet (udp_packet=0x7f4b1069ce90) at tools/atsc3_alc_listener_mde_writer_from_stltp_pcap.cpp:181
